### PR TITLE
Cpu players report readiness

### DIFF
--- a/src/Entities/Game.ts
+++ b/src/Entities/Game.ts
@@ -11,6 +11,19 @@ class Game implements ISubscriber, IReadOnlyGameModel {
   private currentRound: Round | null
   private subscribers: ISubscriber[]
   private shuffleSeed: number
+  private readonly idsOfPlayersThatAreReadyToPlayAgain: Set<string>
+
+  public constructor(players: Player[], dealerIndex: number, shuffleSeed: number) {
+    this.players = players
+    this.currentDealer = dealerIndex
+    this.currentRound = null
+    this.subscribers = []
+    this.shuffleSeed = shuffleSeed
+    this.idsOfPlayersThatAreReadyToPlayAgain = new Set()
+    if (players.length === 4) {
+      this.playRound()
+    }
+  }
 
   public addSubscriber(newSubscriber: ISubscriber): void {
     this.subscribers.push(newSubscriber)
@@ -26,17 +39,6 @@ class Game implements ISubscriber, IReadOnlyGameModel {
 
   public update(): void {
     this.notifySubscribers()
-  }
-
-  public constructor(players: Player[], dealerIndex: number, shuffleSeed: number) {
-    this.players = players
-    this.currentDealer = dealerIndex
-    this.currentRound = null
-    this.subscribers = []
-    this.shuffleSeed = shuffleSeed
-    if (players.length === 4) {
-      this.playRound()
-    }
   }
 
   public getIndexOfPlayerById(id: UniqueIdentifier): number {
@@ -91,10 +93,14 @@ class Game implements ISubscriber, IReadOnlyGameModel {
     this.notifySubscribers()
   }
 
-  public playAgain(): void {
-    this.currentRound?.removeSubscriber(this)
-    this.setNextDealer()
-    this.playRound()
+  public playAgain(playerId: UniqueIdentifier): void {
+    this.idsOfPlayersThatAreReadyToPlayAgain.add(playerId.getId())
+    if (this.idsOfPlayersThatAreReadyToPlayAgain.size === this.players.length) {
+      this.idsOfPlayersThatAreReadyToPlayAgain.clear()
+      this.currentRound?.removeSubscriber(this)
+      this.setNextDealer()
+      this.playRound()
+    }
   }
 
   private setNextDealer(): void {

--- a/src/Entities/TestClasses/Game.test.ts
+++ b/src/Entities/TestClasses/Game.test.ts
@@ -1,9 +1,34 @@
 import Game from '../Game'
+import Player from '../Player'
+import UniqueIdentifier from '../../Utilities/UniqueIdentifier'
 
 describe('Game', () => {
+  let players: Player[]
+  let shuffleSeed: number
+  let game: Game
+
+  beforeEach(() => {
+    players = [
+      new Player('Player 1', new UniqueIdentifier()),
+      new Player('Player 2', new UniqueIdentifier()),
+      new Player('Player 3', new UniqueIdentifier()),
+      new Player('Player 4', new UniqueIdentifier()),
+    ]
+    shuffleSeed = 12345
+    game = new Game(players, 0, shuffleSeed)
+  })
   it('Should accept a seed when the game is created', () => {
-    const shuffleSeed = 12345
     expect(() => new Game([], 0, shuffleSeed)).not.toThrow()
+  })
+  it('should only play again after all players have reported that they are ready', () => {
+    const currentRound = game.getCurrentRound()
+    game.playAgain(new UniqueIdentifier(players[0].getId()))
+    game.playAgain(new UniqueIdentifier(players[1].getId()))
+    game.playAgain(new UniqueIdentifier(players[2].getId()))
+    game.playAgain(new UniqueIdentifier(players[0].getId()))
+    expect(currentRound).toEqual(game.getCurrentRound())
+    game.playAgain(new UniqueIdentifier(players[3].getId()))
+    expect(currentRound).not.toEqual(game.getCurrentRound())
   })
 })
 

--- a/src/InterfaceAdapters/CommandExecutor/GameCommands/GameCommandDTOs/ReadyToPlayAgainCommandDTO.ts
+++ b/src/InterfaceAdapters/CommandExecutor/GameCommands/GameCommandDTOs/ReadyToPlayAgainCommandDTO.ts
@@ -1,0 +1,10 @@
+import CommandDTO from '../../CommandDTO'
+
+interface ReadyToPlayAgainCommandDTO extends CommandDTO {
+  name: 'playAgain'
+  params: {
+    playerId: string
+  }
+}
+
+export default ReadyToPlayAgainCommandDTO

--- a/src/InterfaceAdapters/CommandExecutor/GameCommands/GameCommandFactory.ts
+++ b/src/InterfaceAdapters/CommandExecutor/GameCommands/GameCommandFactory.ts
@@ -8,6 +8,7 @@ import PassCommand from './PassCommand'
 import PlayAgainCommand from './PlayAgainCommand'
 import PlayCommand from './PlayCommand'
 import PlayCommandDTO from './GameCommandDTOs/PlayCommandDTO'
+import ReadyToPlayAgainCommandDTO from './GameCommandDTOs/ReadyToPlayAgainCommandDTO'
 
 class GameCommandFactory implements ICommandFactory {
   private readonly game: IGame
@@ -20,8 +21,8 @@ class GameCommandFactory implements ICommandFactory {
     if (commandDTO.name === 'pass') {
       return new PassCommand(this.game)
     }
-    if (commandDTO.name === 'playAgain') {
-      return new PlayAgainCommand(this.game)
+    if (this.isReadyToPlayAgainCommand(commandDTO)) {
+      return new PlayAgainCommand(this.game, commandDTO.params.playerId)
     }
     if (this.isPlayCommand(commandDTO)) {
       return new PlayCommand(this.game, commandDTO.params.card)
@@ -30,6 +31,10 @@ class GameCommandFactory implements ICommandFactory {
       return new BuryCommand(this.game, commandDTO.params.cards)
     }
     throw Error(`Game command is not recognized: ${JSON.stringify(commandDTO)}`)
+  }
+
+  private isReadyToPlayAgainCommand(command: CommandDTO): command is ReadyToPlayAgainCommandDTO {
+    return command.name === 'playAgain'
   }
 
   private isPlayCommand(command: CommandDTO): command is PlayCommandDTO {

--- a/src/InterfaceAdapters/CommandExecutor/GameCommands/Interfaces/IGame.ts
+++ b/src/InterfaceAdapters/CommandExecutor/GameCommands/Interfaces/IGame.ts
@@ -1,8 +1,9 @@
 import IRound from './IRound'
+import UniqueIdentifier from '../../../../Utilities/UniqueIdentifier'
 
 interface IGame {
   getCurrentRound(): IRound | null
-  playAgain(): void
+  playAgain(playerId: UniqueIdentifier): void
 }
 
 export default IGame

--- a/src/InterfaceAdapters/CommandExecutor/GameCommands/PlayAgainCommand.ts
+++ b/src/InterfaceAdapters/CommandExecutor/GameCommands/PlayAgainCommand.ts
@@ -1,11 +1,12 @@
 import IGame from './Interfaces/IGame'
 import ICommand from '../ICommand'
+import UniqueIdentifier from '../../../Utilities/UniqueIdentifier'
 
 class PlayAgainCommand implements ICommand {
-  constructor(private readonly game: IGame) {}
+  constructor(private readonly game: IGame, private readonly playerId: string) {}
 
   execute(): void {
-    this.game.playAgain()
+    this.game.playAgain(new UniqueIdentifier(this.playerId))
   }
 }
 

--- a/src/InterfaceAdapters/CommandExecutor/GameCommands/TestClasses/GameCommandFactory.test.ts
+++ b/src/InterfaceAdapters/CommandExecutor/GameCommands/TestClasses/GameCommandFactory.test.ts
@@ -4,11 +4,14 @@ import IGame from '../Interfaces/IGame'
 import PassCommand from '../PassCommand'
 import PlayAgainCommand from '../PlayAgainCommand'
 import PlayCommand from '../PlayCommand'
+import UniqueIdentifier from '../../../../Utilities/UniqueIdentifier'
 
 describe('Game Command Factory', () => {
   let gameCommandFactory: GameCommandFactory
   let game: IGame
+  let playerId: UniqueIdentifier
   beforeEach(() => {
+    playerId = new UniqueIdentifier()
     gameCommandFactory = new GameCommandFactory(game)
   })
 
@@ -30,9 +33,9 @@ describe('Game Command Factory', () => {
   })
 
   it('Should create a Play Again Command when given a PlayAgainCommandDTO', () => {
-    expect(gameCommandFactory.getCommand({ name: 'playAgain', params: null })).toEqual(
-      new PlayAgainCommand(game)
-    )
+    expect(
+      gameCommandFactory.getCommand({ name: 'playAgain', params: { playerId: playerId.getId() } })
+    ).toEqual(new PlayAgainCommand(game, playerId.getId()))
   })
 })
 

--- a/src/InterfaceAdapters/CommandExecutor/GameCommands/TestClasses/PlayAgainCommand.test.ts
+++ b/src/InterfaceAdapters/CommandExecutor/GameCommands/TestClasses/PlayAgainCommand.test.ts
@@ -1,10 +1,13 @@
 import IGame from '../Interfaces/IGame'
 import PlayAgainCommand from '../PlayAgainCommand'
+import UniqueIdentifier from '../../../../Utilities/UniqueIdentifier'
 
 describe('Play Again Command', () => {
   let game: IGame
+  let playerId: UniqueIdentifier
 
   beforeEach(() => {
+    playerId = new UniqueIdentifier()
     game = {
       getCurrentRound: jest.fn(),
       playAgain: jest.fn(),
@@ -12,8 +15,8 @@ describe('Play Again Command', () => {
   })
 
   it('Should call play again on the game', () => {
-    new PlayAgainCommand(game).execute()
-    expect(game.playAgain).toHaveBeenCalled()
+    new PlayAgainCommand(game, playerId.getId()).execute()
+    expect(game.playAgain).toHaveBeenCalledWith(playerId)
   })
 })
 

--- a/src/InterfaceAdapters/GameBoardPresenter/GameBoardPresenter.test.ts
+++ b/src/InterfaceAdapters/GameBoardPresenter/GameBoardPresenter.test.ts
@@ -181,7 +181,9 @@ describe('Game Board Presenter', () => {
       presenter.playAgain()
       expect(commandInterface.giveCommand).toHaveBeenCalledWith({
         name: 'playAgain',
-        params: null,
+        params: {
+          playerId: 'georges-id',
+        },
       })
     })
   })

--- a/src/InterfaceAdapters/GameBoardPresenter/GameBoardPresenter.ts
+++ b/src/InterfaceAdapters/GameBoardPresenter/GameBoardPresenter.ts
@@ -4,6 +4,7 @@ import ICommandInterface from '../ICommandInterface'
 import IGameBoardModel from '../IGameBoardModel'
 import IGameBoardPresenter from '../../Views/GamePlayViews/IGameBoardPresenter'
 import ISubscriber from '../../Entities/ISubscriber'
+import PlayerData from '../../Views/GamePlayViews/EndOfRoundReport/PlayerData'
 
 class GameBoardPresenter implements IGameBoardPresenter, ISubscriber {
   private readonly commandInterface: ICommandInterface
@@ -96,9 +97,15 @@ class GameBoardPresenter implements IGameBoardPresenter, ISubscriber {
   }
 
   public playAgain(): void {
+    const localPlayerData = this.model.getDataForLocalPlayer()
+    const localPlayerInfo = this.model
+      .getPlayersData()
+      .find((player: PlayerData) => player.name === localPlayerData.name)
     this.commandInterface.giveCommand({
       name: 'playAgain',
-      params: null,
+      params: {
+        playerId: localPlayerInfo?.id,
+      },
     })
   }
 }

--- a/src/UseCase/TestClasses/CPUPlayer.test.ts
+++ b/src/UseCase/TestClasses/CPUPlayer.test.ts
@@ -1,0 +1,63 @@
+import CPUPlayer from '../CPUPlayer'
+import ICardRanker from '../../Entities/ICardRanker'
+import ICommandInterface from '../../InterfaceAdapters/ICommandInterface'
+import IReadOnlyGameModel from '../../Entities/ReadOnlyEntities/IReadOnlyGameModel'
+import IReadOnlyRound from '../../Entities/ReadOnlyEntities/IReadOnlyRound'
+import UniqueIdentifier from '../../Utilities/UniqueIdentifier'
+
+describe('CPU Player', () => {
+  let name: string
+  let id: UniqueIdentifier
+  let round: IReadOnlyRound
+  let gameModel: IReadOnlyGameModel
+  let cardRanker: ICardRanker
+  let commandInterface: ICommandInterface
+  let cpuPlayer: CPUPlayer
+
+  beforeEach(() => {
+    name = 'Random Name'
+    id = new UniqueIdentifier()
+    round = {
+      getCurrentTrick: jest.fn(),
+      getCurrentTurnPlayer: jest.fn(),
+      getEndOfRoundReport: jest.fn(),
+      getIndexOfDealer: jest.fn(),
+      getIndexOfPicker: jest.fn(),
+      getIndexOfCurrentTurn: jest.fn(),
+      isOver: jest.fn().mockReturnValue(true),
+      isFindingPickerState: jest.fn(),
+      isPickerHasNotBuriedState: jest.fn(),
+    }
+    gameModel = {
+      addSubscriber: jest.fn(),
+      removeSubscriber: jest.fn(),
+      getIndexOfPlayerById: jest.fn(),
+      getNextIndex: jest.fn(),
+      getPlayerById: jest.fn(),
+      getPlayerByIndex: jest.fn(),
+      getCurrentRound: jest.fn().mockReturnValue(round),
+      pick: jest.fn(),
+      updateSubscribers: jest.fn(),
+    }
+    commandInterface = {
+      giveCommand: jest.fn(),
+    }
+    cpuPlayer = new CPUPlayer(name, id, gameModel, cardRanker, commandInterface)
+  })
+
+  it('Should report readiness once when the game has ended', () => {
+    cpuPlayer.update()
+    cpuPlayer.update()
+    cpuPlayer.update()
+    cpuPlayer.update()
+    expect(commandInterface.giveCommand).toHaveBeenCalledTimes(1)
+    expect(commandInterface.giveCommand).toHaveBeenCalledWith({
+      name: 'playAgain',
+      params: {
+        playerId: id.getId(),
+      },
+    })
+  })
+})
+
+export {}

--- a/src/Views/GamePlayViews/EndOfRoundReport/EndOfRoundReport.css
+++ b/src/Views/GamePlayViews/EndOfRoundReport/EndOfRoundReport.css
@@ -30,3 +30,7 @@
 .winner {
   background-color: green;
 }
+
+.ready {
+  text-align: center;
+}

--- a/src/Views/GamePlayViews/EndOfRoundReport/EndOfRoundReport.tsx
+++ b/src/Views/GamePlayViews/EndOfRoundReport/EndOfRoundReport.tsx
@@ -14,7 +14,15 @@ type Props = {
   endOfGamePresenter: EndOfRoundPresenter
 }
 
-class EndOfRoundReport extends Component<Props> {
+type State = {
+  hasClickedReadyToPlayAgain: boolean
+}
+
+class EndOfRoundReport extends Component<Props, State> {
+  state = {
+    hasClickedReadyToPlayAgain: false,
+  }
+
   render() {
     const report = this.props.endOfRoundData.endOfRoundReport
     const players = this.props.endOfRoundData.players
@@ -125,14 +133,23 @@ class EndOfRoundReport extends Component<Props> {
             </Table>
           </Modal.Body>
           <Modal.Footer>
-            <Button
-              variant='primary'
-              onClick={() => {
-                this.props.endOfGamePresenter.playAgain()
-              }}
-            >
-              Play Another Round
-            </Button>
+            {!this.state.hasClickedReadyToPlayAgain && (
+              <Button
+                variant='primary'
+                onClick={() => {
+                  this.props.endOfGamePresenter.playAgain()
+                  this.setState({ hasClickedReadyToPlayAgain: true })
+                }}
+              >
+                Play Another Round
+              </Button>
+            )}
+            {this.state.hasClickedReadyToPlayAgain && (
+              <div className='ready'>
+                Got it. <br />
+                We'll start the next round as soon as everyone else is ready.
+              </div>
+            )}
           </Modal.Footer>
         </Modal>
       )


### PR DESCRIPTION
# RULES OF SHEEPHEAD QUESTION FOR YOU FIRST
Before I get into this MR, something happened and I wanted to confirm with you that it is the correct behavior.

![image](https://user-images.githubusercontent.com/25301008/109912703-d01e7780-7c69-11eb-8036-d9866442177a.png)
I would have expected to only be able to play my club suited cards
The lead card is a trump, but I don't have any trump
And so it's saying I can play any card
But shouldn't it say, "You have to play one of your club cards"?

# Goal of this MR
Before this MR, when you clicked the "Play Again Button" at the end-of-round report it would just send a command to the `Game` to go ahead and start another round. 

The problem with this is that when playing multiplayer, whenever the first person says that they are ready to play another round, the game will bring everyone into the new round, even if someone was still looking at the report.

I guess it's not that big of a deal but I thought it would be better if everyone had to report individually that they were ready to play again rather than everyone being at the mercy of whoever clicks first.

So now what happens if you have clicked "Play Another Round" and there is at least one other player that has not yet clicked it you will see this happen.

![EndOfRoundMessage](https://user-images.githubusercontent.com/25301008/109912558-92215380-7c69-11eb-864f-b6964d906dd1.gif)

So when you are playing against the computer it doesn't happen because as soon as the round is over they immediately report that they are ready. In order to create the above gif, I made it so that they don't report that they are ready.