### PR TITLE
Make Game the shuffle seed manager

### DIFF
--- a/src/Entities/Game.ts
+++ b/src/Entities/Game.ts
@@ -1,11 +1,12 @@
 import BellePlaineRulesCardRanker from './BellePlaineRulesCardRanker'
 import IReadOnlyGameModel from './ReadOnlyEntities/IReadOnlyGameModel'
+import IShuffleSeedManager from './Round/IShuffleSeedManager'
 import ISubscriber from './ISubscriber'
 import Player from './Player'
 import Round from './Round/Round'
 import UniqueIdentifier from '../Utilities/UniqueIdentifier'
 
-class Game implements ISubscriber, IReadOnlyGameModel {
+class Game implements ISubscriber, IReadOnlyGameModel, IShuffleSeedManager {
   private players: Player[]
   private currentDealer: number
   private currentRound: Round | null
@@ -14,7 +15,6 @@ class Game implements ISubscriber, IReadOnlyGameModel {
   private readonly idsOfPlayersThatAreReadyToPlayAgain: Set<string>
 
   public constructor(players: Player[], dealerIndex: number, shuffleSeed: number) {
-    console.log('constructor shuffleSeed', shuffleSeed)
     this.players = players
     this.currentDealer = dealerIndex
     this.currentRound = null
@@ -24,6 +24,14 @@ class Game implements ISubscriber, IReadOnlyGameModel {
     if (players.length === 4) {
       this.playRound()
     }
+  }
+
+  public changeShuffleSeed(): void {
+    this.shuffleSeed++
+  }
+
+  public getShuffleSeed(): number {
+    return this.shuffleSeed
   }
 
   public addSubscriber(newSubscriber: ISubscriber): void {
@@ -79,17 +87,15 @@ class Game implements ISubscriber, IReadOnlyGameModel {
   }
 
   private playRound(): void {
-    console.log('ShuffleSeed Before Increment', this.shuffleSeed)
     this.players.forEach((player) => player.clearCards())
     this.currentRound = new Round(
       this.players,
       this.currentDealer,
-      this.shuffleSeed++,
+      this,
       new BellePlaineRulesCardRanker()
     )
     this.currentRound.addSubscriber(this)
     this.notifySubscribers()
-    console.log('ShuffleSeed After Increment', this.shuffleSeed)
   }
 
   public playAgain(playerId: UniqueIdentifier): void {

--- a/src/Entities/Game.ts
+++ b/src/Entities/Game.ts
@@ -88,6 +88,7 @@ class Game implements ISubscriber, IReadOnlyGameModel, IShuffleSeedManager {
 
   private playRound(): void {
     this.players.forEach((player) => player.clearCards())
+    this.changeShuffleSeed()
     this.currentRound = new Round(
       this.players,
       this.currentDealer,

--- a/src/Entities/Round/IShuffleSeedManager.ts
+++ b/src/Entities/Round/IShuffleSeedManager.ts
@@ -1,0 +1,6 @@
+interface IShuffleSeedManager {
+  changeShuffleSeed(): void
+  getShuffleSeed(): number
+}
+
+export default IShuffleSeedManager

--- a/src/Entities/Round/Round.ts
+++ b/src/Entities/Round/Round.ts
@@ -6,6 +6,7 @@ import ICardRanker from '../ICardRanker'
 import IObservable from '../IObservable'
 import IReadOnlyRound from '../ReadOnlyEntities/IReadOnlyRound'
 import IRoundState from './IRoundState'
+import IShuffleSeedManager from './IShuffleSeedManager'
 import ISubscriber from '../ISubscriber'
 import PickerHasNotBuriedState from './PickerHasNotBuriedState'
 import Player from '../Player'
@@ -16,7 +17,6 @@ class Round implements IRoundState, IObservable, IReadOnlyRound {
   private indexOfDealer: number
   private indexOfCurrentTurn: number
   private blind: Card[]
-  private shuffleSeed: number
   private context: IRoundState
   private _bury: Card[]
   private cardRanker: ICardRanker
@@ -28,7 +28,7 @@ class Round implements IRoundState, IObservable, IReadOnlyRound {
   constructor(
     players: Player[],
     indexOfDealer: number,
-    shuffleSeed: number,
+    private readonly shuffleSeedManager: IShuffleSeedManager,
     cardRanker: ICardRanker
   ) {
     this.players = players
@@ -37,7 +37,6 @@ class Round implements IRoundState, IObservable, IReadOnlyRound {
     this.blind = []
     this.pickerIndex = -1
     this._bury = []
-    this.shuffleSeed = shuffleSeed
     this.cardRanker = cardRanker
     this.context = new FindingPickerState(this)
     this.currentTrick = new Trick(-1)
@@ -168,7 +167,7 @@ class Round implements IRoundState, IObservable, IReadOnlyRound {
   }
 
   public reDeal(): void {
-    this.shuffleSeed++
+    this.shuffleSeedManager.changeShuffleSeed()
     this.removeAllCards()
     this.deal()
   }
@@ -181,7 +180,7 @@ class Round implements IRoundState, IObservable, IReadOnlyRound {
 
   private deal(): void {
     const deck = new Deck(this.cardRanker)
-    deck.shuffle(this.shuffleSeed)
+    deck.shuffle(this.shuffleSeedManager.getShuffleSeed())
 
     this.giveEachPlayerThreeCards(deck)
     this.blind.push(deck.getNextCard())

--- a/src/Entities/TestClasses/Round.test.ts
+++ b/src/Entities/TestClasses/Round.test.ts
@@ -1,6 +1,7 @@
 import Card from '../Card'
 import BellePlaineRulesCardRanker from '../BellePlaineRulesCardRanker'
 import ICardRanker from '../../Entities/ICardRanker'
+import IShuffleSeedManager from '../Round/IShuffleSeedManager'
 import Player from '../Player'
 import Round from '../Round/Round'
 import UniqueIdentifier from '../../Utilities/UniqueIdentifier'
@@ -16,7 +17,14 @@ describe('Round', () => {
   let player4Id: string
   let player4: Player
   let round: Round
+  let shuffleSeedManager: IShuffleSeedManager
+
   beforeEach(() => {
+    shuffleSeedManager = {
+      getShuffleSeed: jest.fn().mockReturnValueOnce(123456789).mockReturnValueOnce(123456790),
+      changeShuffleSeed: jest.fn(),
+    }
+
     cardRanker = new BellePlaineRulesCardRanker()
     player1Id = '4d2f43c3-224d-46ba-bb76-0e383d9ceb5c'
     player1 = new Player('Jesse', new UniqueIdentifier(player1Id))
@@ -33,7 +41,7 @@ describe('Round', () => {
     round = new Round(
       [player1, player2, player3, player4],
       0,
-      123456789,
+      shuffleSeedManager,
       new BellePlaineRulesCardRanker()
     )
   })
@@ -383,7 +391,7 @@ describe('Round', () => {
     expect(actualEndOfRoundReport.tricks[5].cards[3]).toEqual(player2CardData[5])
   })
 
-  it('Should shuffle and re deal if no one picks', () => {
+  it('Should tell the shuffle seed manager to changeShuffleSeed and re deal if no one picks', () => {
     expect(player1.getPlayableCardIds()).toEqual(['7d', 'qh', '9d', '8d', 'kc', '9s'])
     expect(player2.getPlayableCardIds()).toEqual(['qd', 'td', 'kd', 'ah', 'tc', '9c'])
     expect(player3.getPlayableCardIds()).toEqual(['qs', 'jc', 'js', 'jd', 'ad', '9h'])
@@ -396,5 +404,6 @@ describe('Round', () => {
     expect(player2.getPlayableCardIds()).toEqual(['7d', 'qh', 'jd', 'td', 'ts', '9h'])
     expect(player3.getPlayableCardIds()).toEqual(['qs', 'kd', '8d', 'ac', 'ks', 'kh'])
     expect(player4.getPlayableCardIds()).toEqual(['jc', 'jh', 'ad', 'tc', 'th', '9c'])
+    expect(shuffleSeedManager.changeShuffleSeed).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
Closes #21 

The above issue says that the 3rd hand is the same as the 2nd hand, that's not actually what was happening. Explanation below.

# BEFORE
For any round where all players passed, the following round's hand will be the same as the previous round's hand after all players passed.

This is because the `Round.ts` instance was managing its own unique copy of the `shuffleSeed`. And when all players passed, it would only increment its own copy, while the copy that the `Game.ts` instance had would NOT be incremented. This lead to a repeated hand on the following Round.

# SOLUTION
Rather than give the `Round.ts` instance a copy of the shuffle seed, give him a pointer to an object that manages the shuffleseed.

This way there is only ONE shuffle seed.

# DEMO OF DEFECT

These are the first 2 players' hands at the start of the first round:

![image](https://user-images.githubusercontent.com/25301008/112911778-597f6900-90b3-11eb-92ab-5e4d8678b63d.png)

These are the same 2 player' hands after all players have passed:

![image](https://user-images.githubusercontent.com/25301008/112911879-892e7100-90b3-11eb-870d-1605744d7b42.png)

These are the same 2 players' hands at the start of the second round:

![image](https://user-images.githubusercontent.com/25301008/112911948-acf1b700-90b3-11eb-8d60-3b05e0c96ea7.png)

# DEMO OF THIS BRANCH

These are the first 2 players' hands at the start of the first round:
 
![image](https://user-images.githubusercontent.com/25301008/112912246-5638ad00-90b4-11eb-83fc-7b6beb97d25a.png)

These are the same 2 player' hands after all players have passed:

![image](https://user-images.githubusercontent.com/25301008/112912266-6486c900-90b4-11eb-9f50-3fbfca4f7a49.png)

These are the same 2 players' hands at the start of the second round:

![image](https://user-images.githubusercontent.com/25301008/112912313-7e281080-90b4-11eb-8ae6-76aca6deace0.png)
