### PR TITLE
Move the Pass or Pick modal down

### DIFF
--- a/src/Views/GamePlayViews/PassOrPick.css
+++ b/src/Views/GamePlayViews/PassOrPick.css
@@ -1,0 +1,3 @@
+.modal-dialog {
+  margin-top: 425px !important;
+}

--- a/src/Views/GamePlayViews/PassOrPick.tsx
+++ b/src/Views/GamePlayViews/PassOrPick.tsx
@@ -6,6 +6,7 @@ import Spinner from 'react-bootstrap/Spinner'
 import PassOrPickPresenter from './PassOrPickPresenter'
 import PassOrPickViewData from './PassOrPickViewData'
 import SelectableCardHand from './SelectableCardHand'
+import './PassOrPick.css'
 
 type Props = {
   presenter: PassOrPickPresenter


### PR DESCRIPTION
Closes #27 

These changes move the pick or pass modal down so that the player being prompted to pick or pass can see the order of the players so that they can strategically decide whether to pick or pass based on the decisions others have made before.

Here are pictures on two browsers and it appears to look correct for both of them.

![image](https://user-images.githubusercontent.com/25301008/113678747-d68e7d80-9673-11eb-8a56-a392971fa4f1.png)

![image](https://user-images.githubusercontent.com/25301008/113678866-f9b92d00-9673-11eb-8a76-59beabcea267.png)

