### PR TITLE
Make some stylistic changes

### DIFF
--- a/src/Entities/Hand.ts
+++ b/src/Entities/Hand.ts
@@ -1,4 +1,5 @@
 import Card from './Card'
+import Suit from './Suit'
 
 class Hand {
   private hand: Card[]
@@ -9,11 +10,47 @@ class Hand {
 
   public addCard(card: Card): void {
     this.hand.push(card)
-    this.hand.sort(this.sortByRankAscending)
+    this.hand.sort(this.sortBySuitThenRankAscending)
   }
 
-  private sortByRankAscending(cardA: Card, cardB: Card): number {
-    return cardA.getRank() - cardB.getRank()
+  private sortBySuitThenRankAscending(cardA: Card, cardB: Card): number {
+    if (Hand.cardsAreOfSameSuit(cardA, cardB)) {
+      return cardA.getRank() - cardB.getRank()
+    }
+    return Hand.sortBySuit(cardA, cardB)
+  }
+
+  private static sortBySuit(cardA: Card, cardB: Card): number {
+    if (cardA.isTrump()) {
+      return -1
+    }
+    if (cardB.isTrump()) {
+      return 1
+    }
+    return Hand.getNumberForSuit(cardB.getSuit()) - Hand.getNumberForSuit(cardA.getSuit())
+  }
+
+  private static getNumberForSuit(suit: Suit): number {
+    switch (suit) {
+      case Suit.CLUB:
+        return 3
+      case Suit.SPADE:
+        return 2
+      case Suit.HEART:
+        return 1
+      default:
+        throw Error('this should not have happened, all diamond are trump')
+    }
+  }
+
+  private static cardsAreOfSameSuit(cardA: Card, cardB: Card): boolean {
+    if (cardA.isTrump() && cardB.isTrump()) {
+      return true
+    }
+    if (cardA.isTrump() || cardB.isTrump()) {
+      return false
+    }
+    return cardA.getSuit() === cardB.getSuit()
   }
 
   public removeCardFromHand(cardId: string): Card {

--- a/src/Entities/TestClasses/Hand.test.ts
+++ b/src/Entities/TestClasses/Hand.test.ts
@@ -1,4 +1,4 @@
-import ICardRanker from 'Entities/ICardRanker'
+import ICardRanker from '../../Entities/ICardRanker'
 import BellePlaineRulesCardRanker from '../BellePlaineRulesCardRanker'
 import Card from '../Card'
 import Hand from '../Hand'
@@ -65,6 +65,63 @@ describe('Hand', () => {
       cardIdsInHand.forEach((cardId) => hand.addCard(new Card(cardId, cardRanker)))
       const trumpLead = new Card('qc', cardRanker)
       expect(hand.getPlayableCardIds(trumpLead)).toEqual(cardIdsInHand)
+    })
+  })
+
+  describe('Sorting Properly', () => {
+    beforeEach(() => {
+      hand = new Hand()
+      cardRanker = new BellePlaineRulesCardRanker()
+    })
+    it('Should first sort by suit then by rank', () => {
+      hand.addCard(new Card('qc', cardRanker))
+      expect(hand.getPlayableCardIds()).toEqual(['qc'])
+      hand.addCard(new Card('ah', cardRanker))
+      hand.addCard(new Card('jd', cardRanker))
+      hand.addCard(new Card('th', cardRanker))
+      hand.addCard(new Card('ac', cardRanker))
+      hand.addCard(new Card('tc', cardRanker))
+      expect(hand.getPlayableCardIds()).toEqual(['qc', 'jd', 'ac', 'tc', 'ah', 'th'])
+
+      hand.addCard(new Card('td', cardRanker))
+      hand.addCard(new Card('ts', cardRanker))
+      expect(hand.getPlayableCardIds()).toEqual(['qc', 'jd', 'td', 'ac', 'tc', 'ts', 'ah', 'th'])
+
+      hand.addCard(new Card('ad', cardRanker))
+      hand.addCard(new Card('as', cardRanker))
+      expect(hand.getPlayableCardIds()).toEqual([
+        'qc',
+        'jd',
+        'ad',
+        'td',
+        'ac',
+        'tc',
+        'as',
+        'ts',
+        'ah',
+        'th',
+      ])
+
+      hand.addCard(new Card('9h', cardRanker))
+      hand.addCard(new Card('9s', cardRanker))
+      hand.addCard(new Card('9c', cardRanker))
+      hand.addCard(new Card('9d', cardRanker))
+      expect(hand.getPlayableCardIds()).toEqual([
+        'qc',
+        'jd',
+        'ad',
+        'td',
+        '9d',
+        'ac',
+        'tc',
+        '9c',
+        'as',
+        'ts',
+        '9s',
+        'ah',
+        'th',
+        '9h',
+      ])
     })
   })
 })

--- a/src/Entities/TestClasses/Round.test.ts
+++ b/src/Entities/TestClasses/Round.test.ts
@@ -47,7 +47,7 @@ describe('Round', () => {
   })
   it('Should be able to play a round all the way through', async () => {
     expect(player1.getPlayableCardIds()).toEqual(['7d', 'qh', '9d', '8d', 'kc', '9s'])
-    expect(player2.getPlayableCardIds()).toEqual(['qd', 'td', 'kd', 'ah', 'tc', '9c'])
+    expect(player2.getPlayableCardIds()).toEqual(['qd', 'td', 'kd', 'tc', '9c', 'ah'])
     expect(player3.getPlayableCardIds()).toEqual(['qs', 'jc', 'js', 'jd', 'ad', '9h'])
     expect(player4.getPlayableCardIds()).toEqual(['qc', 'ac', 'as', 'ts', 'th', 'kh'])
 
@@ -86,7 +86,7 @@ describe('Round', () => {
     expect(round.getCurrentTurnPlayer().getPlayableCardIds().length).toBe(6)
 
     const round1LeadCard = player2.removeCardFromHand('qd')
-    expect(player2.getPlayableCardIds()).toEqual(['td', 'kd', 'ah', 'tc', '9c'])
+    expect(player2.getPlayableCardIds()).toEqual(['td', 'kd', 'tc', '9c', 'ah'])
     round.play(round1LeadCard)
     // @ts-ignore
     expect(round.getCurrentTrick().getNumCardsPlayed()).toBe(1)
@@ -134,7 +134,7 @@ describe('Round', () => {
     expect(player4.getTricksWon().length).toBe(1)
 
     expect(player1.getPlayableCardIds()).toEqual(['qh', '9d', 'kc', '9s'])
-    expect(player2.getPlayableCardIds()).toEqual(['kd', 'ah', 'tc', '9c'])
+    expect(player2.getPlayableCardIds()).toEqual(['kd', 'tc', '9c', 'ah'])
     expect(player3.getPlayableCardIds()).toEqual(['jc', 'js', 'jh', '9h'])
     expect(player4.getPlayableCardIds()).toEqual(['ac', 'as', 'ts', 'th'])
 
@@ -158,7 +158,7 @@ describe('Round', () => {
     expect(player4.getTricksWon().length).toBe(2)
 
     expect(player1.getPlayableCardIds()).toEqual(['qh', '9d', '9s'])
-    expect(player2.getPlayableCardIds()).toEqual(['kd', 'ah', 'tc'])
+    expect(player2.getPlayableCardIds()).toEqual(['kd', 'tc', 'ah'])
     expect(player3.getPlayableCardIds()).toEqual(['jc', 'js', 'jh'])
     expect(player4.getPlayableCardIds()).toEqual(['as', 'ts', 'th'])
 
@@ -168,7 +168,7 @@ describe('Round', () => {
     expect(round.getCurrentTurnPlayer()).toBe(player1)
     round.play(player1.removeCardFromHand('9s'))
     expect(round.getCurrentTurnPlayer()).toBe(player2)
-    expect(player2.getPlayableCardIds(round4LeadCard)).toEqual(['kd', 'ah', 'tc'])
+    expect(player2.getPlayableCardIds(round4LeadCard)).toEqual(['kd', 'tc', 'ah'])
     round.play(player2.removeCardFromHand('kd'))
     expect(round.getCurrentTurnPlayer()).toBe(player3)
     expect(player3.getPlayableCardIds(round4LeadCard)).toEqual(['jc', 'js', 'jh'])
@@ -180,7 +180,7 @@ describe('Round', () => {
     expect(player4.getTricksWon().length).toBe(2)
 
     expect(player1.getPlayableCardIds()).toEqual(['qh', '9d'])
-    expect(player2.getPlayableCardIds()).toEqual(['ah', 'tc'])
+    expect(player2.getPlayableCardIds()).toEqual(['tc', 'ah'])
     expect(player3.getPlayableCardIds()).toEqual(['js', 'jh'])
     expect(player4.getPlayableCardIds()).toEqual(['ts', 'th'])
 
@@ -393,17 +393,17 @@ describe('Round', () => {
 
   it('Should tell the shuffle seed manager to changeShuffleSeed and re deal if no one picks', () => {
     expect(player1.getPlayableCardIds()).toEqual(['7d', 'qh', '9d', '8d', 'kc', '9s'])
-    expect(player2.getPlayableCardIds()).toEqual(['qd', 'td', 'kd', 'ah', 'tc', '9c'])
+    expect(player2.getPlayableCardIds()).toEqual(['qd', 'td', 'kd', 'tc', '9c', 'ah'])
     expect(player3.getPlayableCardIds()).toEqual(['qs', 'jc', 'js', 'jd', 'ad', '9h'])
     expect(player4.getPlayableCardIds()).toEqual(['qc', 'ac', 'as', 'ts', 'th', 'kh'])
     round.pass()
     round.pass()
     round.pass()
     round.pass()
-    expect(player1.getPlayableCardIds()).toEqual(['qc', 'qd', 'js', 'ah', 'kc', '9s'])
+    expect(player1.getPlayableCardIds()).toEqual(['qc', 'qd', 'js', 'kc', '9s', 'ah'])
     expect(player2.getPlayableCardIds()).toEqual(['7d', 'qh', 'jd', 'td', 'ts', '9h'])
     expect(player3.getPlayableCardIds()).toEqual(['qs', 'kd', '8d', 'ac', 'ks', 'kh'])
-    expect(player4.getPlayableCardIds()).toEqual(['jc', 'jh', 'ad', 'tc', 'th', '9c'])
+    expect(player4.getPlayableCardIds()).toEqual(['jc', 'jh', 'ad', 'tc', '9c', 'th'])
     expect(shuffleSeedManager.changeShuffleSeed).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/Views/App.css
+++ b/src/Views/App.css
@@ -6,7 +6,7 @@ body {
 section {
   background: url('./images/background.jpg');
   width: 800px;
-  height: 700px;
+  height: 600px;
   margin: 30px auto;
   overflow: hidden;
   border-radius: 10px;

--- a/src/Views/GamePlayViews/Card.css
+++ b/src/Views/GamePlayViews/Card.css
@@ -1,11 +1,11 @@
 .playing-card img {
   margin-top: 5px;
-  width: 110px;
+  width: 80px;
 }
 
 .playing-card .playable {
   box-sizing: content-box;
-  border: green solid 5px;
+  box-shadow: 5px 5px 5px 0 white;
 }
 
 .playing-card .playable:hover {

--- a/src/Views/GamePlayViews/Hand.css
+++ b/src/Views/GamePlayViews/Hand.css
@@ -1,5 +1,5 @@
 #hand {
-  width: 50%;
+  width: 75%;
   margin: auto;
 }
 
@@ -7,9 +7,6 @@
   margin: auto;
   display: inline;
   width: 110px;
-  margin-left: -75px;
+  margin-left: 10px;
   z-index: 1;
-}
-#hand .playing-card:first-child {
-  margin-left: 0px;
 }

--- a/src/Views/GamePlayViews/PassOrPick.css
+++ b/src/Views/GamePlayViews/PassOrPick.css
@@ -1,3 +1,3 @@
 #pick-or-pass-modal {
-  margin-top: 425px !important;
+  margin-top: 350px !important;
 }

--- a/src/Views/GamePlayViews/PlayerLayout/PlayerLayout.css
+++ b/src/Views/GamePlayViews/PlayerLayout/PlayerLayout.css
@@ -1,4 +1,5 @@
 #player-layout {
+  height: 470px;
   display: grid;
   grid-template-columns: 20% 20% 20% 20% 20%;
   grid-template-rows: 20% 20% 20% 20% 20%;

--- a/src/Views/index.css
+++ b/src/Views/index.css
@@ -1,3 +1,5 @@
+@import-normalize;
+
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',


### PR DESCRIPTION
Shrink the cards
Spread out the cards
Shorten the height of the view
Change the selectable cards to show white shadow rather than green

Closes #40 

Now the cards are spaced out across the bottom.

![image](https://user-images.githubusercontent.com/25301008/114280738-886cd780-99ef-11eb-98f6-30af30b9eace.png)

Closes #43 

Now the sort order is 1st by suit, TRUMP, CLUB, SPADE, HEART
Then by rank

here are two examples that are now sorted differently than they would have been before.

### Example 1

Under the old sorting method, the 10 of hearts would have been to the left of the king.

![image](https://user-images.githubusercontent.com/25301008/114281678-9709bd80-99f4-11eb-9c97-28c0839bc757.png)

### Example 2

Under the old sorting method, the Ace of Hearts would have been to the left of the 9 of clubs

![image](https://user-images.githubusercontent.com/25301008/114281715-d3d5b480-99f4-11eb-895c-aac4396724c3.png)



