### PR TITLE
Fix trick taking eval

### DIFF
--- a/src/Entities/Hand.ts
+++ b/src/Entities/Hand.ts
@@ -1,4 +1,5 @@
 import Card from './Card'
+import Suit from './Suit'
 
 class Hand {
   private hand: Card[]
@@ -9,11 +10,47 @@ class Hand {
 
   public addCard(card: Card): void {
     this.hand.push(card)
-    this.hand.sort(this.sortByRankAscending)
+    this.hand.sort(this.sortBySuitThenRankAscending)
   }
 
-  private sortByRankAscending(cardA: Card, cardB: Card): number {
-    return cardA.getRank() - cardB.getRank()
+  private sortBySuitThenRankAscending(cardA: Card, cardB: Card): number {
+    if (Hand.cardsAreOfSameSuit(cardA, cardB)) {
+      return cardA.getRank() - cardB.getRank()
+    }
+    return Hand.sortBySuit(cardA, cardB)
+  }
+
+  private static sortBySuit(cardA: Card, cardB: Card): number {
+    if (cardA.isTrump()) {
+      return -1
+    }
+    if (cardB.isTrump()) {
+      return 1
+    }
+    return Hand.getNumberForSuit(cardB.getSuit()) - Hand.getNumberForSuit(cardA.getSuit())
+  }
+
+  private static getNumberForSuit(suit: Suit): number {
+    switch (suit) {
+      case Suit.CLUB:
+        return 3
+      case Suit.SPADE:
+        return 2
+      case Suit.HEART:
+        return 1
+      default:
+        throw Error('this should not have happened, all diamond are trump')
+    }
+  }
+
+  private static cardsAreOfSameSuit(cardA: Card, cardB: Card): boolean {
+    if (cardA.isTrump() && cardB.isTrump()) {
+      return true
+    }
+    if (cardA.isTrump() || cardB.isTrump()) {
+      return false
+    }
+    return cardA.getSuit() === cardB.getSuit()
   }
 
   public removeCardFromHand(cardId: string): Card {

--- a/src/Entities/TestClasses/Hand.test.ts
+++ b/src/Entities/TestClasses/Hand.test.ts
@@ -1,4 +1,4 @@
-import ICardRanker from 'Entities/ICardRanker'
+import ICardRanker from '../../Entities/ICardRanker'
 import BellePlaineRulesCardRanker from '../BellePlaineRulesCardRanker'
 import Card from '../Card'
 import Hand from '../Hand'
@@ -65,6 +65,63 @@ describe('Hand', () => {
       cardIdsInHand.forEach((cardId) => hand.addCard(new Card(cardId, cardRanker)))
       const trumpLead = new Card('qc', cardRanker)
       expect(hand.getPlayableCardIds(trumpLead)).toEqual(cardIdsInHand)
+    })
+  })
+
+  describe('Sorting Properly', () => {
+    beforeEach(() => {
+      hand = new Hand()
+      cardRanker = new BellePlaineRulesCardRanker()
+    })
+    it('Should first sort by suit then by rank', () => {
+      hand.addCard(new Card('qc', cardRanker))
+      expect(hand.getPlayableCardIds()).toEqual(['qc'])
+      hand.addCard(new Card('ah', cardRanker))
+      hand.addCard(new Card('jd', cardRanker))
+      hand.addCard(new Card('th', cardRanker))
+      hand.addCard(new Card('ac', cardRanker))
+      hand.addCard(new Card('tc', cardRanker))
+      expect(hand.getPlayableCardIds()).toEqual(['qc', 'jd', 'ac', 'tc', 'ah', 'th'])
+
+      hand.addCard(new Card('td', cardRanker))
+      hand.addCard(new Card('ts', cardRanker))
+      expect(hand.getPlayableCardIds()).toEqual(['qc', 'jd', 'td', 'ac', 'tc', 'ts', 'ah', 'th'])
+
+      hand.addCard(new Card('ad', cardRanker))
+      hand.addCard(new Card('as', cardRanker))
+      expect(hand.getPlayableCardIds()).toEqual([
+        'qc',
+        'jd',
+        'ad',
+        'td',
+        'ac',
+        'tc',
+        'as',
+        'ts',
+        'ah',
+        'th',
+      ])
+
+      hand.addCard(new Card('9h', cardRanker))
+      hand.addCard(new Card('9s', cardRanker))
+      hand.addCard(new Card('9c', cardRanker))
+      hand.addCard(new Card('9d', cardRanker))
+      expect(hand.getPlayableCardIds()).toEqual([
+        'qc',
+        'jd',
+        'ad',
+        'td',
+        '9d',
+        'ac',
+        'tc',
+        '9c',
+        'as',
+        'ts',
+        '9s',
+        'ah',
+        'th',
+        '9h',
+      ])
     })
   })
 })

--- a/src/Entities/TestClasses/Round.test.ts
+++ b/src/Entities/TestClasses/Round.test.ts
@@ -47,7 +47,7 @@ describe('Round', () => {
   })
   it('Should be able to play a round all the way through', async () => {
     expect(player1.getPlayableCardIds()).toEqual(['7d', 'qh', '9d', '8d', 'kc', '9s'])
-    expect(player2.getPlayableCardIds()).toEqual(['qd', 'td', 'kd', 'ah', 'tc', '9c'])
+    expect(player2.getPlayableCardIds()).toEqual(['qd', 'td', 'kd', 'tc', '9c', 'ah'])
     expect(player3.getPlayableCardIds()).toEqual(['qs', 'jc', 'js', 'jd', 'ad', '9h'])
     expect(player4.getPlayableCardIds()).toEqual(['qc', 'ac', 'as', 'ts', 'th', 'kh'])
 
@@ -86,7 +86,7 @@ describe('Round', () => {
     expect(round.getCurrentTurnPlayer().getPlayableCardIds().length).toBe(6)
 
     const round1LeadCard = player2.removeCardFromHand('qd')
-    expect(player2.getPlayableCardIds()).toEqual(['td', 'kd', 'ah', 'tc', '9c'])
+    expect(player2.getPlayableCardIds()).toEqual(['td', 'kd', 'tc', '9c', 'ah'])
     round.play(round1LeadCard)
     // @ts-ignore
     expect(round.getCurrentTrick().getNumCardsPlayed()).toBe(1)
@@ -134,7 +134,7 @@ describe('Round', () => {
     expect(player4.getTricksWon().length).toBe(1)
 
     expect(player1.getPlayableCardIds()).toEqual(['qh', '9d', 'kc', '9s'])
-    expect(player2.getPlayableCardIds()).toEqual(['kd', 'ah', 'tc', '9c'])
+    expect(player2.getPlayableCardIds()).toEqual(['kd', 'tc', '9c', 'ah'])
     expect(player3.getPlayableCardIds()).toEqual(['jc', 'js', 'jh', '9h'])
     expect(player4.getPlayableCardIds()).toEqual(['ac', 'as', 'ts', 'th'])
 
@@ -158,7 +158,7 @@ describe('Round', () => {
     expect(player4.getTricksWon().length).toBe(2)
 
     expect(player1.getPlayableCardIds()).toEqual(['qh', '9d', '9s'])
-    expect(player2.getPlayableCardIds()).toEqual(['kd', 'ah', 'tc'])
+    expect(player2.getPlayableCardIds()).toEqual(['kd', 'tc', 'ah'])
     expect(player3.getPlayableCardIds()).toEqual(['jc', 'js', 'jh'])
     expect(player4.getPlayableCardIds()).toEqual(['as', 'ts', 'th'])
 
@@ -168,7 +168,7 @@ describe('Round', () => {
     expect(round.getCurrentTurnPlayer()).toBe(player1)
     round.play(player1.removeCardFromHand('9s'))
     expect(round.getCurrentTurnPlayer()).toBe(player2)
-    expect(player2.getPlayableCardIds(round4LeadCard)).toEqual(['kd', 'ah', 'tc'])
+    expect(player2.getPlayableCardIds(round4LeadCard)).toEqual(['kd', 'tc', 'ah'])
     round.play(player2.removeCardFromHand('kd'))
     expect(round.getCurrentTurnPlayer()).toBe(player3)
     expect(player3.getPlayableCardIds(round4LeadCard)).toEqual(['jc', 'js', 'jh'])
@@ -180,7 +180,7 @@ describe('Round', () => {
     expect(player4.getTricksWon().length).toBe(2)
 
     expect(player1.getPlayableCardIds()).toEqual(['qh', '9d'])
-    expect(player2.getPlayableCardIds()).toEqual(['ah', 'tc'])
+    expect(player2.getPlayableCardIds()).toEqual(['tc', 'ah'])
     expect(player3.getPlayableCardIds()).toEqual(['js', 'jh'])
     expect(player4.getPlayableCardIds()).toEqual(['ts', 'th'])
 
@@ -393,17 +393,17 @@ describe('Round', () => {
 
   it('Should tell the shuffle seed manager to changeShuffleSeed and re deal if no one picks', () => {
     expect(player1.getPlayableCardIds()).toEqual(['7d', 'qh', '9d', '8d', 'kc', '9s'])
-    expect(player2.getPlayableCardIds()).toEqual(['qd', 'td', 'kd', 'ah', 'tc', '9c'])
+    expect(player2.getPlayableCardIds()).toEqual(['qd', 'td', 'kd', 'tc', '9c', 'ah'])
     expect(player3.getPlayableCardIds()).toEqual(['qs', 'jc', 'js', 'jd', 'ad', '9h'])
     expect(player4.getPlayableCardIds()).toEqual(['qc', 'ac', 'as', 'ts', 'th', 'kh'])
     round.pass()
     round.pass()
     round.pass()
     round.pass()
-    expect(player1.getPlayableCardIds()).toEqual(['qc', 'qd', 'js', 'ah', 'kc', '9s'])
+    expect(player1.getPlayableCardIds()).toEqual(['qc', 'qd', 'js', 'kc', '9s', 'ah'])
     expect(player2.getPlayableCardIds()).toEqual(['7d', 'qh', 'jd', 'td', 'ts', '9h'])
     expect(player3.getPlayableCardIds()).toEqual(['qs', 'kd', '8d', 'ac', 'ks', 'kh'])
-    expect(player4.getPlayableCardIds()).toEqual(['jc', 'jh', 'ad', 'tc', 'th', '9c'])
+    expect(player4.getPlayableCardIds()).toEqual(['jc', 'jh', 'ad', 'tc', '9c', 'th'])
     expect(shuffleSeedManager.changeShuffleSeed).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/Entities/TestClasses/Trick.test.ts
+++ b/src/Entities/TestClasses/Trick.test.ts
@@ -1,0 +1,63 @@
+import BellePlaineRulesCardRanker from '../BellePlaineRulesCardRanker'
+import Card from '../Card'
+import ICardRanker from '../ICardRanker'
+import Player from '../Player'
+import Trick from '../Trick'
+import UniqueIdentifier from '../../Utilities/UniqueIdentifier'
+
+describe('Giving Trick to Winner', () => {
+  let player1: Player
+  let player2: Player
+  let player3: Player
+  let player4: Player
+  let cardRanker: ICardRanker
+  beforeEach(() => {
+    player1 = new Player('player 1', new UniqueIdentifier())
+    player2 = new Player('player 2', new UniqueIdentifier())
+    player3 = new Player('player 3', new UniqueIdentifier())
+    player4 = new Player('player 4', new UniqueIdentifier())
+    cardRanker = new BellePlaineRulesCardRanker()
+  })
+  it('Should give the trick to the highest ranking card when all cards are trump', () => {
+    let trick = new Trick(1)
+    expect(trick.getLeadCard()).toBeUndefined()
+    trick.addCardToTrick(new Card('qc', cardRanker), player1)
+    trick.addCardToTrick(new Card('7d', cardRanker), player2)
+    trick.addCardToTrick(new Card('qs', cardRanker), player3)
+    trick.addCardToTrick(new Card('qh', cardRanker), player4)
+    trick.giveToHighestRankingCardPlayer()
+    expect(player1.getTricksWon()).toEqual([trick])
+  })
+
+  it('Should give the trick to the highest ranking card when all cards are the same suit', () => {
+    let trick = new Trick(1)
+    trick.addCardToTrick(new Card('9c', cardRanker), player1)
+    trick.addCardToTrick(new Card('tc', cardRanker), player2)
+    trick.addCardToTrick(new Card('ac', cardRanker), player3)
+    trick.addCardToTrick(new Card('kc', cardRanker), player4)
+    trick.giveToHighestRankingCardPlayer()
+    expect(player3.getTricksWon()).toEqual([trick])
+  })
+
+  it('Should give the trick to the trump card even if some players are following suit', () => {
+    let trick = new Trick(1)
+    trick.addCardToTrick(new Card('9c', cardRanker), player1)
+    trick.addCardToTrick(new Card('td', cardRanker), player2)
+    trick.addCardToTrick(new Card('ac', cardRanker), player3)
+    trick.addCardToTrick(new Card('kd', cardRanker), player4)
+    trick.giveToHighestRankingCardPlayer()
+    expect(player2.getTricksWon()).toEqual([trick])
+  })
+
+  it('Should give the trick to the lead card if non of the players can following suit', () => {
+    let trick = new Trick(1)
+    trick.addCardToTrick(new Card('9h', cardRanker), player1)
+    trick.addCardToTrick(new Card('tc', cardRanker), player2)
+    trick.addCardToTrick(new Card('ac', cardRanker), player3)
+    trick.addCardToTrick(new Card('as', cardRanker), player4)
+    trick.giveToHighestRankingCardPlayer()
+    expect(player1.getTricksWon()).toEqual([trick])
+  })
+})
+
+export {}

--- a/src/Entities/TestClasses/Trick.test.ts
+++ b/src/Entities/TestClasses/Trick.test.ts
@@ -27,6 +27,7 @@ describe('Giving Trick to Winner', () => {
     trick.addCardToTrick(new Card('qh', cardRanker), player4)
     trick.giveToHighestRankingCardPlayer()
     expect(player1.getTricksWon()).toEqual([trick])
+    expect(trick.getTrickData().winningCardIndex).toEqual(0)
   })
 
   it('Should give the trick to the highest ranking card when all cards are the same suit', () => {
@@ -37,6 +38,7 @@ describe('Giving Trick to Winner', () => {
     trick.addCardToTrick(new Card('kc', cardRanker), player4)
     trick.giveToHighestRankingCardPlayer()
     expect(player3.getTricksWon()).toEqual([trick])
+    expect(trick.getTrickData().winningCardIndex).toEqual(2)
   })
 
   it('Should give the trick to the trump card even if some players are following suit', () => {
@@ -47,6 +49,7 @@ describe('Giving Trick to Winner', () => {
     trick.addCardToTrick(new Card('kd', cardRanker), player4)
     trick.giveToHighestRankingCardPlayer()
     expect(player2.getTricksWon()).toEqual([trick])
+    expect(trick.getTrickData().winningCardIndex).toEqual(1)
   })
 
   it('Should give the trick to the lead card if non of the players can following suit', () => {
@@ -57,6 +60,7 @@ describe('Giving Trick to Winner', () => {
     trick.addCardToTrick(new Card('as', cardRanker), player4)
     trick.giveToHighestRankingCardPlayer()
     expect(player1.getTricksWon()).toEqual([trick])
+    expect(trick.getTrickData().winningCardIndex).toEqual(0)
   })
 })
 

--- a/src/Entities/Trick.ts
+++ b/src/Entities/Trick.ts
@@ -2,6 +2,7 @@ import Card from './Card'
 import CardPlayedByData from './DataStructures/CardPlayedByData'
 import IReadOnlyTrick from '../GameEntityInterfaces/ReadOnlyEntities/IReadOnlyTrick'
 import Player from './Player'
+import Suit from './Suit'
 import TrickData from './DataStructures/TrickData'
 
 class Trick implements IReadOnlyTrick {
@@ -60,19 +61,30 @@ class Trick implements IReadOnlyTrick {
   }
 
   public getWinnerOfTrick(): Player {
+    if (!this.cardsInTrick.some((card) => card.isTrump())) {
+      return this.playerOfCard[
+        this.getIndexOfHighestRankingCardOfSuit(this.getLeadCard()?.getSuit())
+      ]
+    }
     return this.playerOfCard[this.getIndexOfHighestRankingCardInTrick()]
   }
 
   private getIndexOfHighestRankingCardInTrick(): number {
-    return this.cardsInTrick.findIndex((card) => card.getRank() === this.getHighestRankInTrick())
+    return this.cardsInTrick.findIndex(
+      (card) => card.getRank() === this.getHighestRankFromArray(this.cardsInTrick)
+    )
   }
 
-  private getHighestRankInTrick(): number {
-    return Math.min(...this.getRankOfCardsInTrick())
+  private getIndexOfHighestRankingCardOfSuit(suit: Suit | undefined) {
+    return this.cardsInTrick.findIndex(
+      (card) =>
+        card.getRank() ===
+        this.getHighestRankFromArray(this.cardsInTrick.filter((card) => card.getSuit() === suit))
+    )
   }
 
-  private getRankOfCardsInTrick(): number[] {
-    return this.cardsInTrick.map((card) => card.getRank())
+  private getHighestRankFromArray(cards: Card[]): number {
+    return Math.min(...cards.map((card) => card.getRank()))
   }
 }
 

--- a/src/Entities/Trick.ts
+++ b/src/Entities/Trick.ts
@@ -40,7 +40,9 @@ class Trick implements IReadOnlyTrick {
   public getTrickData(): TrickData {
     return {
       cards: this.getCardPlayedByData(),
-      winningCardIndex: this.getIndexOfHighestRankingCardInTrick(),
+      winningCardIndex: this.playerOfCard.findIndex(
+        (player) => player.getId() === this.getWinnerOfTrick().getId()
+      ),
     }
   }
 

--- a/src/Views/App.css
+++ b/src/Views/App.css
@@ -6,7 +6,7 @@ body {
 section {
   background: url('./images/background.jpg');
   width: 800px;
-  height: 700px;
+  height: 600px;
   margin: 30px auto;
   overflow: hidden;
   border-radius: 10px;

--- a/src/Views/GamePlayViews/Card.css
+++ b/src/Views/GamePlayViews/Card.css
@@ -1,11 +1,11 @@
 .playing-card img {
   margin-top: 5px;
-  width: 110px;
+  width: 80px;
 }
 
 .playing-card .playable {
   box-sizing: content-box;
-  border: green solid 5px;
+  box-shadow: 5px 5px 5px 0 white;
 }
 
 .playing-card .playable:hover {

--- a/src/Views/GamePlayViews/Hand.css
+++ b/src/Views/GamePlayViews/Hand.css
@@ -1,5 +1,5 @@
 #hand {
-  width: 50%;
+  width: 75%;
   margin: auto;
 }
 
@@ -7,9 +7,6 @@
   margin: auto;
   display: inline;
   width: 110px;
-  margin-left: -75px;
+  margin-left: 10px;
   z-index: 1;
-}
-#hand .playing-card:first-child {
-  margin-left: 0px;
 }

--- a/src/Views/GamePlayViews/PassOrPick.css
+++ b/src/Views/GamePlayViews/PassOrPick.css
@@ -1,3 +1,3 @@
 #pick-or-pass-modal {
-  margin-top: 425px !important;
+  margin-top: 350px !important;
 }

--- a/src/Views/GamePlayViews/PlayerLayout/PlayerLayout.css
+++ b/src/Views/GamePlayViews/PlayerLayout/PlayerLayout.css
@@ -1,4 +1,5 @@
 #player-layout {
+  height: 470px;
   display: grid;
   grid-template-columns: 20% 20% 20% 20% 20%;
   grid-template-rows: 20% 20% 20% 20% 20%;

--- a/src/Views/index.css
+++ b/src/Views/index.css
@@ -1,3 +1,5 @@
+@import-normalize;
+
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',


### PR DESCRIPTION
Closes #46 

### BEFORE
Tricks always went to the highest-ranking card

### AFTER
It does not go to the highest-ranking card that *followed or trumped* suit.

Cards that failed to follow suit are ineligible to win the trick

### DEMO

Both tricks one and two in this case illustrate the new behavior.

The old code would have attributed trick 1 to the Ace of Clubs

The old code would have attributed trick 2 to the ten of clubs

As you can see the player that won the trick was also given the opportunity to lead the following trick as they should be.

![image](https://user-images.githubusercontent.com/25301008/114283858-ebb33580-9a00-11eb-89a2-3424f89c2e33.png)
