### PR TITLE
Hand of doubles

### DIFF
--- a/src/Entities/Round/IHandOfDoublesAdder.ts
+++ b/src/Entities/Round/IHandOfDoublesAdder.ts
@@ -1,0 +1,6 @@
+interface IHandOfDoublesManager {
+  addHandOfDoubles(): void
+  isHandOfDoubles(): boolean
+}
+
+export default IHandOfDoublesManager

--- a/src/Entities/Round/Round.ts
+++ b/src/Entities/Round/Round.ts
@@ -3,6 +3,7 @@ import Deck from '../Deck'
 import EndOfRoundData from './EndOfRoundReportData'
 import FindingPickerState from './FindingPickerState'
 import ICardRanker from '../ICardRanker'
+import IHandOfDoublesManager from './IHandOfDoublesAdder'
 import IObservable from '../IObservable'
 import IPlayerPayer from '../../Payment/IPlayerPayer'
 import IReadOnlyRound from '../../GameEntityInterfaces/ReadOnlyEntities/IReadOnlyRound'
@@ -31,7 +32,7 @@ class Round implements IRoundState, IRound, IObservable, IReadOnlyRound {
   constructor(
     players: Player[],
     indexOfDealer: number,
-    private readonly shuffleSeedManager: IShuffleSeedManager,
+    private readonly shuffleSeedManager: IShuffleSeedManager & IHandOfDoublesManager,
     cardRanker: ICardRanker,
     private readonly playerPayer: IPlayerPayer
   ) {
@@ -62,6 +63,7 @@ class Round implements IRoundState, IRound, IObservable, IReadOnlyRound {
           currentHandCentsWon: player.currentHandCentsWon,
         }
       }),
+      isDoubleRound: this.shuffleSeedManager.isHandOfDoubles(),
       endOfRoundReport: this.getEndOfRoundReport(),
     })
   }
@@ -196,6 +198,7 @@ class Round implements IRoundState, IRound, IObservable, IReadOnlyRound {
   }
 
   public reDeal(): void {
+    this.shuffleSeedManager.addHandOfDoubles()
     this.shuffleSeedManager.changeShuffleSeed()
     this.removeAllCards()
     this.deal()

--- a/src/Entities/TestClasses/Round.test.ts
+++ b/src/Entities/TestClasses/Round.test.ts
@@ -409,5 +409,6 @@ describe('Round', () => {
     expect(player3.getPlayableCardIds()).toEqual(['qs', 'kd', '8d', 'ac', 'ks', 'kh'])
     expect(player4.getPlayableCardIds()).toEqual(['jc', 'jh', 'ad', 'tc', '9c', 'th'])
     expect(shuffleSeedManager.changeShuffleSeed).toHaveBeenCalledTimes(1)
+    expect(shuffleSeedManager.addHandOfDoubles).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/Entities/TestClasses/Round.test.ts
+++ b/src/Entities/TestClasses/Round.test.ts
@@ -1,6 +1,7 @@
 import Card from '../Card'
 import BellePlaineRulesCardRanker from '../BellePlaineRulesCardRanker'
 import ICardRanker from '../../Entities/ICardRanker'
+import IHandOfDoublesManager from '../Round/IHandOfDoublesAdder'
 import IShuffleSeedManager from '../Round/IShuffleSeedManager'
 import Player from '../Player'
 import Round from '../Round/Round'
@@ -17,12 +18,14 @@ describe('Round', () => {
   let player4Id: string
   let player4: Player
   let round: Round
-  let shuffleSeedManager: IShuffleSeedManager
+  let shuffleSeedManager: IShuffleSeedManager & IHandOfDoublesManager
 
   beforeEach(() => {
     shuffleSeedManager = {
       getShuffleSeed: jest.fn().mockReturnValueOnce(123456789).mockReturnValueOnce(123456790),
       changeShuffleSeed: jest.fn(),
+      addHandOfDoubles: jest.fn(),
+      isHandOfDoubles: jest.fn(),
     }
 
     cardRanker = new BellePlaineRulesCardRanker()

--- a/src/GameEntityInterfaces/ReadOnlyEntities/IReadOnlyGameModel.ts
+++ b/src/GameEntityInterfaces/ReadOnlyEntities/IReadOnlyGameModel.ts
@@ -9,6 +9,7 @@ interface IReadOnlyGameModel extends IObservable {
   getPlayerById(id: UniqueIdentifier): Player
   getPlayerByIndex(index: number): Player
   getCurrentRound(): IReadOnlyRound | null
+  isHandOfDoubles(): boolean
   updateSubscribers(): void
 }
 

--- a/src/InterfaceAdapters/GameBoardPresenter/GameBoardPresenter.test.ts
+++ b/src/InterfaceAdapters/GameBoardPresenter/GameBoardPresenter.test.ts
@@ -1,3 +1,4 @@
+import { pause } from '../../Utilities/TestingUtilities'
 import GameBoardPresenter from './GameBoardPresenter'
 import GameBoardViewData from '../../Views/GamePlayViews/GameBoardViewData'
 import ICommandInterface from '../ICommandInterface'
@@ -5,7 +6,6 @@ import IGameBoardModel from '../IGameBoardModel'
 import ISubscriber from '../../Entities/ISubscriber'
 import PlayerDataWithWinnings from '../../Views/GamePlayViews/EndOfRoundReport/PlayerDataWithWinnings'
 import PlayerLayoutData from '../GamePresenter/PlayerLayoutData'
-import { pause } from '../../Utilities/TestingUtilities'
 
 describe('Game Board Presenter', () => {
   let pauseDurationAfterTrick: number
@@ -90,6 +90,7 @@ describe('Game Board Presenter', () => {
       getPlayersData: jest.fn().mockReturnValue(playersData),
       getPickerIndex: jest.fn().mockReturnValueOnce(0).mockReturnValueOnce(1).mockReturnValue(0),
       getEndOfRoundReport: jest.fn().mockReturnValue(undefined),
+      isHandOfDoubles: jest.fn().mockReturnValue(false),
     }
     commandInterface = {
       giveCommand: jest.fn(),
@@ -132,7 +133,9 @@ describe('Game Board Presenter', () => {
           endOfRoundReport: undefined,
           pickerIndex: 0,
           players: playersData,
+          isDoubleRound: false,
         },
+        shouldShowDoublesBadge: false,
       }
     })
 
@@ -285,7 +288,9 @@ describe('Game Board Presenter', () => {
               },
             ],
             pickerIndex: 1,
+            isDoubleRound: false,
           },
+          shouldShowDoublesBadge: false,
         }
         let followingState: GameBoardViewData = {
           allPlayerData: {
@@ -364,7 +369,9 @@ describe('Game Board Presenter', () => {
               },
             ],
             pickerIndex: 1,
+            isDoubleRound: false,
           },
+          shouldShowDoublesBadge: false,
         }
         model = {
           addSubscriber: jest.fn(),
@@ -395,6 +402,7 @@ describe('Game Board Presenter', () => {
           getPlayersData: jest.fn().mockReturnValue(triggeringState.endOfRoundViewData.players),
           getPickerIndex: jest.fn().mockReturnValue(1),
           getEndOfRoundReport: jest.fn().mockReturnValue(undefined),
+          isHandOfDoubles: jest.fn().mockReturnValue(false),
         }
         presenter = new GameBoardPresenter(commandInterface, model, pauseDurationAfterTrick)
         presenter.setView(view)

--- a/src/InterfaceAdapters/GameBoardPresenter/GameBoardPresenter.ts
+++ b/src/InterfaceAdapters/GameBoardPresenter/GameBoardPresenter.ts
@@ -62,7 +62,9 @@ class GameBoardPresenter implements IGameBoardPresenter, ISubscriber {
           players: this.model.getPlayersData(),
           pickerIndex: this.model.getPickerIndex(),
           endOfRoundReport: this.model.getEndOfRoundReport(),
+          isDoubleRound: this.model.isHandOfDoubles(),
         },
+        shouldShowDoublesBadge: this.model.isHandOfDoubles(),
       }
       if (
         this.playerDataToServe === undefined &&

--- a/src/InterfaceAdapters/GamePresenter/GameBoardModel.ts
+++ b/src/InterfaceAdapters/GamePresenter/GameBoardModel.ts
@@ -20,6 +20,10 @@ class GameBoardModel implements ISubscriber, IGameBoardModel {
     this.game.addSubscriber(this)
   }
 
+  public isHandOfDoubles(): boolean {
+    return this.game.isHandOfDoubles()
+  }
+
   public addSubscriber(subscriber: ISubscriber): void {
     this.subscriber = subscriber
   }

--- a/src/InterfaceAdapters/IGameBoardModel.ts
+++ b/src/InterfaceAdapters/IGameBoardModel.ts
@@ -8,6 +8,7 @@ interface IGameBoardModel extends IObservable {
   getDataForPlayerAcross(): PlayerLayoutData
   getDataForPlayerToLeft(): PlayerLayoutData
   getDataForPlayerToRight(): PlayerLayoutData
+  isHandOfDoubles(): boolean
   isPicking(): boolean
   isShowingPassOrPickForm(): boolean
   getHand(): string[]

--- a/src/OppositionTeamMemberIdentifier/OppositionTeamMemberIdentifier.test.ts
+++ b/src/OppositionTeamMemberIdentifier/OppositionTeamMemberIdentifier.test.ts
@@ -197,6 +197,7 @@ describe('Given an index it will decide whether the player is a member of the op
         },
       ],
       endOfRoundReport,
+      isDoubleRound: false,
     }
   })
 

--- a/src/Payment/QuartersPlayerPayer.ts
+++ b/src/Payment/QuartersPlayerPayer.ts
@@ -11,8 +11,9 @@ class QuartersPlayerPayer implements IPlayerPayer {
   givePlayersTheirPay(players: IPayablePlayer[], endOfRoundViewData: EndOfRoundViewData): void {
     const teamOutcome = this.scoreOutcomeGetter.getRoundTeamOutcome(endOfRoundViewData)
     const choppingMultiplier = this.pickerWentAlone(players, teamOutcome) ? 3 : 1
+    const doublesMultiplier = endOfRoundViewData.isDoubleRound ? 2 : 1
     const oppositionTeamMemberCentsWon =
-      this.getOppositionTeamMemberWinnings(teamOutcome) * choppingMultiplier
+      this.getOppositionTeamMemberWinnings(teamOutcome) * choppingMultiplier * doublesMultiplier
     const pickingTeamMemberCentsWon = -1 * oppositionTeamMemberCentsWon * choppingMultiplier
 
     players.forEach((player) => {

--- a/src/Payment/TestClasses/QuartersPlayerPayer.test.ts
+++ b/src/Payment/TestClasses/QuartersPlayerPayer.test.ts
@@ -286,6 +286,22 @@ describe('Quarters Player Payer', () => {
         expect(player3.giveCentsForRound).toHaveBeenCalledWith(-225)
         expect(player3.giveCentsForRound).toHaveBeenCalledWith(-225)
       })
+      it('Should pay 6 quarters to the picking team if the score is 0 to 120 AND it is a hand of doubles', () => {
+        teamOutcome.pickingTeamScore = 120
+        teamOutcome.oppositionTeamScore = 0
+        teamOutcome.pickingTeamTricksWon = 6
+        teamOutcome.oppositionTricksWon = 0
+        endOfRoundViewData.isDoubleRound = true
+        scoreOutcomeGetter = {
+          getRoundTeamOutcome: jest.fn().mockReturnValue(teamOutcome),
+        }
+        playerPayer = new QuartersPlayerPayer(scoreOutcomeGetter)
+        playerPayer.givePlayersTheirPay(players, endOfRoundViewData)
+        expect(player1.giveCentsForRound).toHaveBeenCalledWith(225 * 3 * 2)
+        expect(player2.giveCentsForRound).toHaveBeenCalledWith(-225 * 2)
+        expect(player3.giveCentsForRound).toHaveBeenCalledWith(-225 * 2)
+        expect(player3.giveCentsForRound).toHaveBeenCalledWith(-225 * 2)
+      })
     })
   })
 })

--- a/src/Payment/TestClasses/QuartersPlayerPayer.test.ts
+++ b/src/Payment/TestClasses/QuartersPlayerPayer.test.ts
@@ -22,6 +22,10 @@ describe('Quarters Player Payer', () => {
   let endOfRoundViewData: EndOfRoundViewData
 
   beforeEach(() => {
+    // @ts-ignore
+    endOfRoundViewData = {
+      isDoubleRound: false,
+    }
     player1Id = new UniqueIdentifier()
     player2Id = new UniqueIdentifier()
     player3Id = new UniqueIdentifier()

--- a/src/Views/App.css
+++ b/src/Views/App.css
@@ -44,9 +44,7 @@ td.light {
 }
 
 .doubles-badge {
-  position: absolute;
   margin-left: 0.25em;
   margin-top: 0.1em;
-  padding: 0;
-  display: inline;
+  position: absolute;
 }

--- a/src/Views/App.css
+++ b/src/Views/App.css
@@ -42,3 +42,11 @@ section {
 td.light {
   color: gray;
 }
+
+.doubles-badge {
+  position: absolute;
+  margin-left: 0.25em;
+  margin-top: 0.1em;
+  padding: 0;
+  display: inline;
+}

--- a/src/Views/GamePlayViews/EndOfRoundReport/EndOfRoundViewData.ts
+++ b/src/Views/GamePlayViews/EndOfRoundReport/EndOfRoundViewData.ts
@@ -3,6 +3,7 @@ import PlayerDataWithWinnings from './PlayerDataWithWinnings'
 
 interface EndOfRoundViewData {
   endOfRoundReport: EndOfRoundData | undefined
+  isDoubleRound: boolean
   pickerIndex: number | undefined
   pickerWentAlone: boolean
   players: PlayerDataWithWinnings[]

--- a/src/Views/GamePlayViews/GameBoard.tsx
+++ b/src/Views/GamePlayViews/GameBoard.tsx
@@ -1,4 +1,5 @@
 import { Component, ReactElement } from 'react'
+import Badge from 'react-bootstrap/esm/Badge'
 import EndOfRoundReport from './EndOfRoundReport/EndOfRoundReport'
 import Hand from './Hand'
 import IGameBoardPresenter from './IGameBoardPresenter'
@@ -31,6 +32,13 @@ class GameBoard extends Component<Props> implements ISubscriber {
             presenter={this.props.presenter}
             data={this.props.presenter.getGameBoardViewData().passOrPickViewData}
           />
+        )}
+        {this.props.presenter.getGameBoardViewData().shouldShowDoublesBadge && (
+          <h4 className='doubles-badge'>
+            <Badge variant='danger'>
+              <strong>DOUBLES</strong>
+            </Badge>
+          </h4>
         )}
         <PlayerLayout allPlayerData={this.props.presenter.getGameBoardViewData().allPlayerData} />
         <Hand

--- a/src/Views/GamePlayViews/GameBoardViewData.ts
+++ b/src/Views/GamePlayViews/GameBoardViewData.ts
@@ -5,9 +5,10 @@ import PlayerLayoutDisplayData from './PlayerLayout/PlayerLayoutDisplayData'
 
 interface GameBoardViewData {
   allPlayerData: PlayerLayoutDisplayData
+  endOfRoundViewData: EndOfRoundViewData
   handViewData: LocalPlayerHandViewData
   passOrPickViewData: PassOrPickViewData
-  endOfRoundViewData: EndOfRoundViewData
+  shouldShowDoublesBadge: boolean
 }
 
 export default GameBoardViewData


### PR DESCRIPTION
Closes #29 

This MR makes it so that if the current hand is a hand of doubles it is displayed to the players.

It also doubles the hand payouts after they are calculated if the hand is a hand of doubles.

For this MR, the only way to get a hand of doubles is if everyone passes on the chance to pick.

If everyone passes again, another hand of doubles will be played after the current hand finishes.