### PR TITLE
Add no trick pick penalty

### DIFF
--- a/src/Payment/QuartersPlayerPayer.ts
+++ b/src/Payment/QuartersPlayerPayer.ts
@@ -16,13 +16,24 @@ class QuartersPlayerPayer implements IPlayerPayer {
       this.getOppositionTeamMemberWinnings(teamOutcome) * choppingMultiplier * doublesMultiplier
     const pickingTeamMemberCentsWon = -1 * oppositionTeamMemberCentsWon * choppingMultiplier
 
+    const noTrickPickPayment = teamOutcome.pickerTricksWon === 0 ? 100 : 0
+
     players.forEach((player) => {
       if (teamOutcome.isMemberOfOpposition(new UniqueIdentifier(player.getId()))) {
-        player.giveCentsForRound(oppositionTeamMemberCentsWon)
+        player.giveCentsForRound(oppositionTeamMemberCentsWon + noTrickPickPayment)
       } else {
-        player.giveCentsForRound(pickingTeamMemberCentsWon)
+        player.giveCentsForRound(
+          pickingTeamMemberCentsWon +
+            (this.isPicker(player.getId(), teamOutcome)
+              ? -3 * noTrickPickPayment
+              : noTrickPickPayment)
+        )
       }
     })
+  }
+
+  private isPicker(playerId: string, teamOutcome: IRoundTeamOutcome): boolean {
+    return new UniqueIdentifier(playerId).equals(teamOutcome.pickerId)
   }
 
   private pickerWentAlone(players: IPayablePlayer[], teamOutcome: IRoundTeamOutcome): boolean {

--- a/src/RoundOutcomeDeterminer/IRoundTeamOutcome.ts
+++ b/src/RoundOutcomeDeterminer/IRoundTeamOutcome.ts
@@ -5,6 +5,8 @@ interface IRoundTeamOutcome {
   getPlayerScore(playerId: UniqueIdentifier): number
   oppositionTeamScore: number
   oppositionTricksWon: number
+  pickerId: UniqueIdentifier
+  pickerTricksWon: number
   pickingTeamScore: number
   pickingTeamTricksWon: number
 }

--- a/src/RoundOutcomeDeterminer/RoundTeamOutcome.ts
+++ b/src/RoundOutcomeDeterminer/RoundTeamOutcome.ts
@@ -53,6 +53,19 @@ class RoundTeamOutcome implements IRoundTeamOutcome {
     return 6 - this._oppositionTricksWon
   }
 
+  public get pickerId(): UniqueIdentifier {
+    if (this.endOfRoundViewData.pickerIndex !== undefined) {
+      return new UniqueIdentifier(
+        this.endOfRoundViewData.players[this.endOfRoundViewData.pickerIndex].id
+      )
+    }
+    return new UniqueIdentifier()
+  }
+
+  public get pickerTricksWon(): number {
+    return this.getPlayerTricksWon(this.pickerId)
+  }
+
   public getPlayerScore = (id: UniqueIdentifier): number => {
     return this.getTricksWonByPlayer(id).reduce((total: number, trick: TrickData) => {
       return (


### PR DESCRIPTION
Closes #44 

Now after the base payouts have been calculated for each player, if the picker didn't get a trick, another dollar is given to each player from the picker who loses 3 dollars. This is independent of which team won or lost and by how much etc.